### PR TITLE
getLoginClient added for digest auth batched requests

### DIFF
--- a/lib/api.coffee
+++ b/lib/api.coffee
@@ -30,4 +30,5 @@ module.exports =
   RetsParamError: errors.RetsParamError
   Client: Client
   getAutoLogoutClient: Client.getAutoLogoutClient
+  getLoginClient: Client.getLoginClient
   getReplyTag: replyCodes.getReplyTag

--- a/lib/client.coffee
+++ b/lib/client.coffee
@@ -125,5 +125,11 @@ Client.getAutoLogoutClient = (settings, handler) -> Promise.try () ->
     .finally () ->
       client.logout()
 
+Client.getLoginClient = (settings, handler) -> Promise.try () ->
+  client = new Client(settings)
+  client.login()
+  .then () ->
+    Promise.try () ->
+      handler(client)
 
 module.exports = Client


### PR DESCRIPTION
getAutoLogoutClient destroys the server session for digest auth batched requests. GetLoginClient keeps the user logged in. We need the session to remain active for all subsequent calls and only at the end of the batching logout.

